### PR TITLE
Remove incorrect link

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,4 +30,3 @@ Place |Team or User | Public Score | Private Score | Summary of Model
 
 #### [Interview with winners](http://drivendata.co/blog//)
 
-#### Benchmark Blog Post: ["Benchmark - Predicting Poverty"](http://drivendata.co/blog/worldbank-poverty-benchmark/)


### PR DESCRIPTION
Currently there's a copy-and-pasted link to the benchmark for a different competition.

If there's a benchmark for this competition, we could add it. But I did not find one.